### PR TITLE
Add pdq namespace

### DIFF
--- a/pdqsort.h
+++ b/pdqsort.h
@@ -17,6 +17,8 @@
        being the original software.
 
     3. This notice may not be removed or altered from any source distribution.
+
+    [Note - June, 2017: I have added a namespace while maintaining backwards compatibility - Daniel Baker.]
 */
 
 
@@ -524,16 +526,7 @@ inline void sort(Iter begin, Iter end, Compare comp) {
 template<class Iter>
 inline void sort(Iter begin, Iter end) {
     typedef typename std::iterator_traits<Iter>::value_type T;
-    sort(begin, end, std::less<T>());
-}
-
-template<class Iter>
-inline void pdqsort(Iter begin, Iter end) {
-    ::pdq::sort(begin, end);
-}
-template<class Iter, class Compare>
-inline void pdqsort(Iter begin, Iter end, Compare comp) {
-    ::pdq::sort(begin, end, comp);
+    ::pdq::sort(begin, end, std::less<T>());
 }
 
 template<class Iter, class Compare>
@@ -543,15 +536,15 @@ inline void sort_branchless(Iter begin, Iter end, Compare comp) {
         begin, end, comp, pdqsort_detail::log2(end - begin));
 }
 
-template<class Iter, class Compare>
-inline void pdqsort_branchless(Iter begin, Iter end, Compare comp) {
-    ::pdq::pdqsort_branchless<Iter, Compare>(begin, end, comp);
-}
-
 template<class Iter>
 inline void sort_branchless(Iter begin, Iter end) {
     typedef typename std::iterator_traits<Iter>::value_type T;
     sort_branchless(begin, end, std::less<T>());
+}
+
+template<class Iter, class Compare>
+inline void pdqsort_branchless(Iter begin, Iter end, Compare comp) {
+    ::pdq::sort_branchless<Iter, Compare>(begin, end, comp);
 }
 
 template<class Iter>
@@ -561,6 +554,11 @@ inline void pdqsort_branchless(Iter begin, Iter end) {
 }
 
 } // namespace pdq
+
+template<typename Iter,class Compare>
+void pdqsort(Iter begin, Iter end, Compare cmp) {::pdq::sort(begin, end, cmp);}
+template<typename Iter,class Compare>
+void pdqsort(Iter begin, Iter end) {::pdq::sort(begin, end, std::less<typename std::iterator_traits<Iter>::value_type>());}
 
 
 #undef PDQSORT_PREFER_MOVE

--- a/pdqsort.h
+++ b/pdqsort.h
@@ -38,6 +38,8 @@
 #endif
 
 
+namespace pdq {
+
 namespace pdqsort_detail {
     enum {
         // Partitions below this size are sorted using insertion sort.
@@ -505,7 +507,7 @@ namespace pdqsort_detail {
 
 
 template<class Iter, class Compare>
-inline void pdqsort(Iter begin, Iter end, Compare comp) {
+inline void sort(Iter begin, Iter end, Compare comp) {
     if (begin == end) return;
 
 #if __cplusplus >= 201103L
@@ -520,23 +522,45 @@ inline void pdqsort(Iter begin, Iter end, Compare comp) {
 }
 
 template<class Iter>
-inline void pdqsort(Iter begin, Iter end) {
+inline void sort(Iter begin, Iter end) {
     typedef typename std::iterator_traits<Iter>::value_type T;
-    pdqsort(begin, end, std::less<T>());
+    sort(begin, end, std::less<T>());
+}
+
+template<class Iter>
+inline void pdqsort(Iter begin, Iter end) {
+    ::pdq::sort(begin, end);
+}
+template<class Iter, class Compare>
+inline void pdqsort(Iter begin, Iter end, Compare comp) {
+    ::pdq::sort(begin, end, comp);
 }
 
 template<class Iter, class Compare>
-inline void pdqsort_branchless(Iter begin, Iter end, Compare comp) {
+inline void sort_branchless(Iter begin, Iter end, Compare comp) {
     if (begin == end) return;
     pdqsort_detail::pdqsort_loop<Iter, Compare, true>(
         begin, end, comp, pdqsort_detail::log2(end - begin));
 }
 
+template<class Iter, class Compare>
+inline void pdqsort_branchless(Iter begin, Iter end, Compare comp) {
+    ::pdq::pdqsort_branchless<Iter, Compare>(begin, end, comp);
+}
+
+template<class Iter>
+inline void sort_branchless(Iter begin, Iter end) {
+    typedef typename std::iterator_traits<Iter>::value_type T;
+    sort_branchless(begin, end, std::less<T>());
+}
+
 template<class Iter>
 inline void pdqsort_branchless(Iter begin, Iter end) {
     typedef typename std::iterator_traits<Iter>::value_type T;
-    pdqsort_branchless(begin, end, std::less<T>());
+    sort_branchless<Iter>(begin, end, std::less<T>());
 }
+
+} // namespace pdq
 
 
 #undef PDQSORT_PREFER_MOVE

--- a/pdqsort.h
+++ b/pdqsort.h
@@ -17,6 +17,8 @@
        being the original software.
 
     3. This notice may not be removed or altered from any source distribution.
+
+    [Note - June, 2017: I have added a namespace while maintaining backwards compatibility - Daniel Baker.]
 */
 
 
@@ -37,6 +39,8 @@
     #define PDQSORT_PREFER_MOVE(x) (x)
 #endif
 
+
+namespace pdq {
 
 namespace pdqsort_detail {
     enum {
@@ -505,7 +509,7 @@ namespace pdqsort_detail {
 
 
 template<class Iter, class Compare>
-inline void pdqsort(Iter begin, Iter end, Compare comp) {
+inline void sort(Iter begin, Iter end, Compare comp) {
     if (begin == end) return;
 
 #if __cplusplus >= 201103L
@@ -520,24 +524,28 @@ inline void pdqsort(Iter begin, Iter end, Compare comp) {
 }
 
 template<class Iter>
-inline void pdqsort(Iter begin, Iter end) {
+inline void sort(Iter begin, Iter end) {
     typedef typename std::iterator_traits<Iter>::value_type T;
-    pdqsort(begin, end, std::less<T>());
+    ::pdq::sort(begin, end, std::less<T>());
 }
 
 template<class Iter, class Compare>
-inline void pdqsort_branchless(Iter begin, Iter end, Compare comp) {
+inline void sort_branchless(Iter begin, Iter end, Compare comp) {
     if (begin == end) return;
     pdqsort_detail::pdqsort_loop<Iter, Compare, true>(
         begin, end, comp, pdqsort_detail::log2(end - begin));
 }
 
 template<class Iter>
-inline void pdqsort_branchless(Iter begin, Iter end) {
+inline void sort_branchless(Iter begin, Iter end) {
     typedef typename std::iterator_traits<Iter>::value_type T;
-    pdqsort_branchless(begin, end, std::less<T>());
+    sort_branchless(begin, end, std::less<T>());
 }
 
+} // namespace pdq
+
+#define pdqsort ::pdq::sort
+#define pdqsort_branchless ::pdq::sort_branchless
 
 #undef PDQSORT_PREFER_MOVE
 


### PR DESCRIPTION
Adds a pdq namespace so that one can `use pdq::sort` or `use std::sort` and switch back and forth easily. Added `pdqsort` functions back in so that this change does not break code using the old interface.

It's a small, mostly cosmetic change, of course.