### PR TITLE
Fix MSVC 2015 warning when sorting vector<size_t>

### DIFF
--- a/pdqsort.h
+++ b/pdqsort.h
@@ -140,7 +140,7 @@ namespace pdqsort_detail {
                 while (sift != begin && comp(tmp, *--sift_1));
 
                 *sift = PDQSORT_PREFER_MOVE(tmp);
-                limit += cur - sift;
+                limit += int(cur - sift);
             }
         }
 
@@ -275,7 +275,7 @@ namespace pdqsort_detail {
         }
 
         int l_size = 0, r_size = 0;
-        int unknown_left = (last - first) - ((num_r || num_l) ? block_size : 0);
+        int unknown_left = int((last - first) - ((num_r || num_l) ? block_size : 0));
         if (num_r) {
             // Handle leftover block by assigning the unknown elements to the other block.
             l_size = unknown_left;


### PR DESCRIPTION
MSVC 2015 would produce a warning 4244 (conversion from int64 to int) on
both of these code lines, when compiling to x64, and sorting a
vector<size_t>.

As far as I can tell, these casts will not alter the behaviour of pdqsort.