### PR TITLE
Improved C++11 detection on Visual Studio

### DIFF
--- a/pdqsort.h
+++ b/pdqsort.h
@@ -29,7 +29,12 @@
 #include <utility>
 #include <iterator>
 
-#if __cplusplus >= 201103L
+#ifndef PDQSORT_HAS_CPP11
+    #define PDQSORT_HAS_CPP11 (__cplusplus >= 201103L || _MSVC_LANG >= 201103L)
+    // Visual Studio has broken __cplusplus
+#endif
+
+#if PDQSORT_HAS_CPP11
     #include <cstdint>
     #include <type_traits>
     #define PDQSORT_PREFER_MOVE(x) std::move(x)
@@ -58,7 +63,7 @@ namespace pdqsort_detail {
 
     };
 
-#if __cplusplus >= 201103L
+#if PDQSORT_HAS_CPP11
     template<class T> struct is_default_compare : std::false_type { };
     template<class T> struct is_default_compare<std::less<T>> : std::true_type { };
     template<class T> struct is_default_compare<std::greater<T>> : std::true_type { };
@@ -162,7 +167,7 @@ namespace pdqsort_detail {
 
     template<class T>
     inline T* align_cacheline(T* p) {
-#if defined(UINTPTR_MAX) && __cplusplus >= 201103L
+#if defined(UINTPTR_MAX) && PDQSORT_HAS_CPP11
         std::uintptr_t ip = reinterpret_cast<std::uintptr_t>(p);
 #else
         std::size_t ip = reinterpret_cast<std::size_t>(p);
@@ -496,7 +501,7 @@ template<class Iter, class Compare>
 inline void pdqsort(Iter begin, Iter end, Compare comp) {
     if (begin == end) return;
 
-#if __cplusplus >= 201103L
+#if PDQSORT_HAS_CPP11
     pdqsort_detail::pdqsort_loop<Iter, Compare,
         pdqsort_detail::is_default_compare<typename std::decay<Compare>::type>::value &&
         std::is_arithmetic<typename std::iterator_traits<Iter>::value_type>::value>(


### PR DESCRIPTION
Visual Studio has broken __cplusplus
(See: https://docs.microsoft.com/en-us/cpp/build/reference/zc-cplusplus?view=msvc-160)

Instead one can use _MSVC_LANG
(See: https://docs.microsoft.com/en-us/cpp/preprocessor/predefined-macros?view=msvc-160)

The user can override the behaviour by defining PDQSORT_HAS_CPP11 before including pdqsort.h.