### PR TITLE
Move check inside of condition

### DIFF
--- a/pdqsort.h
+++ b/pdqsort.h
@@ -139,9 +139,9 @@ namespace pdqsort_detail {
 
                 *sift = PDQSORT_PREFER_MOVE(tmp);
                 limit += cur - sift;
+
+                if (limit > partial_insertion_sort_limit) return false;
             }
-            
-            if (limit > partial_insertion_sort_limit) return false;
         }
 
         return true;


### PR DESCRIPTION
In `partial_insertion_sort`, I don't think we need to check whether `limit > partial_insertion_sort_limit` if we're outside the `if` as we only change the value of `limit` inside the `if`.